### PR TITLE
ANDROID: ag x86: disable wake alarms

### DIFF
--- a/fs/timerfd.c
+++ b/fs/timerfd.c
@@ -415,6 +415,15 @@ SYSCALL_DEFINE2(timerfd_create, int, clockid, int, flags)
 	BUILD_BUG_ON(TFD_CLOEXEC != O_CLOEXEC);
 	BUILD_BUG_ON(TFD_NONBLOCK != O_NONBLOCK);
 
+	// disabling alarms for android on x86 platforms
+	// doing it in a way that won't cause errors in frameworks/base/apex/jobscheduler/service/jni/com_android_server_alarm_AlarmManagerService.cpp
+	if(clockid == CLOCK_REALTIME_ALARM){
+		clockid = CLOCK_REALTIME;
+	}
+	if(clockid == CLOCK_BOOTTIME_ALARM){
+		clockid = CLOCK_BOOTTIME;
+	}
+
 	if ((flags & ~TFD_CREATE_FLAGS) ||
 	    (clockid != CLOCK_MONOTONIC &&
 	     clockid != CLOCK_REALTIME &&

--- a/kernel/time/posix-timers.c
+++ b/kernel/time/posix-timers.c
@@ -498,6 +498,12 @@ static int common_timer_create(struct k_itimer *new_timer)
 static int do_timer_create(clockid_t which_clock, struct sigevent *event,
 			   timer_t __user *created_timer_id)
 {
+	if(which_clock == CLOCK_REALTIME_ALARM){
+		which_clock = CLOCK_REALTIME;
+	}
+	if(which_clock == CLOCK_BOOTTIME_ALARM){
+		which_clock = CLOCK_BOOTTIME;
+	}
 	const struct k_clock *kc = clockid_to_kclock(which_clock);
 	struct k_itimer *new_timer;
 	int error, new_timer_id;


### PR DESCRIPTION
On x86 platforms, especially laptops, it might make sense to never wake device up just to fetch notifications, or perform other tasks that android would wake device up for

This change ensures that no device waking alarmtimer is ever queued by userspace, so it would also solve the issue noticed in https://github.com/BlissRoms-x86/platform_frameworks_base/commit/a9f5a3de8ce23e89da5051ca4b7ba8d7bd80c857

an alternative to https://github.com/BlissRoms-x86/platform_frameworks_base/pull/7