### PR TITLE
HACK on HACK suppress cs35l41 logspam

### DIFF
--- a/sound/soc/codecs/cs35l41.c
+++ b/sound/soc/codecs/cs35l41.c
@@ -379,9 +379,11 @@ static irqreturn_t cs35l41_irq(int irq, void *data)
 
 	ret = pm_runtime_resume_and_get(cs35l41->dev);
 	if (ret < 0) {
+		/*
 		dev_err(cs35l41->dev,
 			"pm_runtime_resume_and_get failed in %s: %d\n",
 			__func__, ret);
+		*/
 		return IRQ_NONE;
 	}
 


### PR DESCRIPTION
***
note that proper implementation of shared boost was mainlined since 6.4 so DO NOT apply the valve patch set and this logspam suppression on and beyond 6.4
***

using e26b5a7f1f87e12746c76b3ee9858488b7884515 on linux-6.1.y with valve's/cirrus' out of tree shared boost implementation causes logspam due to runtime pm was disabled on the out of tree implementation